### PR TITLE
Some minor fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ set(PACKAGE_VERSION "0.0.0a")
 set(PACKAGE_STRING "${PACKAGE_NAME} ${PACKAGE_VERSION}")
 set(PACKAGE_TARNAME "${PACKAGE_NAME}")
 
+option(BUILD_docs "build the documents" ON)
 option(BUILD_tests "build the tests" ON)
 option(BUILD_translucent "build translucent" OFF)
 
@@ -19,8 +20,12 @@ endif(BUILD_tests)
 
 include(GossDetectPlatform)
 include(GossDetectDependencies)
-include(GossPandoc)
+if(BUILD_docs)
+    include(GossPandoc)
+endif(BUILD_docs)
 
 add_subdirectory(src)
-add_subdirectory(docs)
+if(BUILD_docs)
+    add_subdirectory(docs)
+endif(BUILD_docs)
 

--- a/src/PhysicalFileFactory.cc
+++ b/src/PhysicalFileFactory.cc
@@ -63,12 +63,12 @@ public:
                     << errinfo_errno(errno)
                     << errinfo_file_name(mFileName));
         }
-        mFile.exceptions(ifstream::badbit);
+        mFile.exceptions(std::ifstream::badbit);
     }
 
 private:
     string mFileName;
-    ifstream mFile;
+    std::ifstream mFile;
 };
 
 class GzippedInHolder : public FileFactory::InHolder
@@ -89,14 +89,14 @@ public:
                     << errinfo_errno(errno)
                     << errinfo_file_name(mFileName));
         }
-        mFile.exceptions(ifstream::badbit);
+        mFile.exceptions(std::ifstream::badbit);
         mFilter.push(gzip_decompressor());
         mFilter.push(mFile);
     }
 
 private:
     string mFileName;
-    ifstream mFile;
+    std::ifstream mFile;
     filtering_stream<input> mFilter;
 };
 
@@ -119,14 +119,14 @@ public:
                     << errinfo_errno(errno)
                     << errinfo_file_name(mFileName));
         }
-        mFile.exceptions(ifstream::badbit);
+        mFile.exceptions(std::ifstream::badbit);
         mFilter.push(bzip2_decompressor(false, 63493103));
         mFilter.push(mFile);
     }
 
 private:
     string mFileName;
-    ifstream mFile;
+    std::ifstream mFile;
     filtering_stream<input> mFilter;
 };
 
@@ -162,12 +162,12 @@ public:
                     << errinfo_errno(errno)
                     << errinfo_file_name(mFileName));
         }
-        mFile.exceptions(ofstream::badbit);
+        mFile.exceptions(std::ofstream::badbit);
     }
 
 private:
     string mFileName;
-    ofstream mFile;
+    std::ofstream mFile;
 };
 
 class PlainMappedHolder : public FileFactory::MappedHolder
@@ -211,14 +211,14 @@ public:
                     << errinfo_errno(errno)
                     << errinfo_file_name(mFileName));
         }
-        mFile.exceptions(ofstream::badbit);
+        mFile.exceptions(std::ofstream::badbit);
         mFilter.push(gzip_compressor());
         mFilter.push(mFile);
     }
 
 private:
     string mFileName;
-    ofstream mFile;
+    std::ofstream mFile;
     filtering_stream<output> mFilter;
 };
 
@@ -241,14 +241,14 @@ public:
                     << errinfo_errno(errno)
                     << errinfo_file_name(mFileName));
         }
-        mFile.exceptions(ofstream::badbit);
+        mFile.exceptions(std::ofstream::badbit);
         mFilter.push(bzip2_compressor());
         mFilter.push(mFile);
     }
 
 private:
     string mFileName;
-    ofstream mFile;
+    std::ofstream mFile;
     filtering_stream<output> mFilter;
 };
 

--- a/src/testPhysicalFileFactory.cc
+++ b/src/testPhysicalFileFactory.cc
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE(testMoreOutputDetail)
 
         int const* li = get_error_info<throw_line>(exc);
         BOOST_CHECK(li != NULL);
-        BOOST_CHECK_EQUAL(*li, 169);
+        BOOST_CHECK_EQUAL(*li, 163);
 
         const char* const* fi = get_error_info<throw_file>(exc);
         BOOST_CHECK(fi != NULL);


### PR DESCRIPTION
    - Conditional building of documents for platforms without pandoc

    - Some OS X compilers with some versions of Boost apparently
      have a problem resolving fstreams in std and fstreams in
      boost::filesystem. No idea why.