### PR TITLE
Fix for boost::noncopyable

### DIFF
--- a/src/FibHeap.hh
+++ b/src/FibHeap.hh
@@ -34,6 +34,11 @@
 #define BOOST_UTILITY_HPP
 #endif
 
+#ifndef BOOST_NONCOPYABLE_HPP
+#include <boost/noncopyable.hpp>
+#define BOOST_NONCOPYABLE_HPP
+#endif
+
 #ifndef STD_IOSTREAM
 #include <iostream>
 #define STD_IOSTREAM

--- a/src/GossCmdBuildDb.cc
+++ b/src/GossCmdBuildDb.cc
@@ -34,6 +34,7 @@
 #include "TrivialVector.hh"
 
 #include <algorithm>
+#include <boost/noncopyable.hpp>
 #include <boost/lexical_cast.hpp>
 #include <thread>
 #include <boost/tuple/tuple.hpp>

--- a/src/LevenbergMarquardt.hh
+++ b/src/LevenbergMarquardt.hh
@@ -34,6 +34,11 @@
 #define BOOST_NUMERIC_UBLAS_MATRIX_HPP
 #endif
 
+#ifndef BOOST_NONCOPYABLE_HPP
+#include <boost/noncopyable.hpp>
+#define BOOST_NONCOPYABLE_HPP
+#endif
+
 #ifndef LOGGER_HH
 #include "Logger.hh"
 #endif

--- a/src/LineSource.hh
+++ b/src/LineSource.hh
@@ -24,6 +24,11 @@
 #define BOOST_UTILITY_HPP
 #endif
 
+#ifndef BOOST_NONCOPYABLE_HPP
+#include <boost/noncopyable.hpp>
+#define BOOST_NONCOPYABLE_HPP
+#endif
+
 #ifndef FILEFACTORY_HH
 #include "FileFactory.hh"
 #endif

--- a/src/MultithreadedBatchTask.hh
+++ b/src/MultithreadedBatchTask.hh
@@ -33,6 +33,11 @@
 #define BOOST_EXCEPTION_PTR_HPP
 #endif // BOOST_EXCEPTION_PTR_HPP
 
+#ifndef BOOST_NONCOPYABLE_HPP
+#include <boost/noncopyable.hpp>
+#define BOOST_NONCOPYABLE_HPP
+#endif
+
 class MultithreadedBatchTask : private boost::noncopyable
 {
 public:

--- a/src/ResolveTranscripts.hh
+++ b/src/ResolveTranscripts.hh
@@ -22,6 +22,11 @@
 #define BOOST_UTILITY_HPP
 #endif
 
+#ifndef BOOST_NONCOPYABLE_HPP
+#include <boost/noncopyable.hpp>
+#define BOOST_NONCOPYABLE_HPP
+#endif
+
 #ifndef STD_MEMORY
 #include <memory>
 #define STD_MEMORY

--- a/src/ThreadGroup.hh
+++ b/src/ThreadGroup.hh
@@ -19,6 +19,11 @@
 #define STD_LIST
 #endif
 
+#ifndef BOOST_NONCOPYABLE_HPP
+#include <boost/noncopyable.hpp>
+#define BOOST_NONCOPYABLE_HPP
+#endif
+
 class ThreadGroup : private boost::noncopyable
 {
 public:

--- a/src/WorkQueue.hh
+++ b/src/WorkQueue.hh
@@ -9,6 +9,7 @@
 #ifndef WORKQUEUE_HH
 #define WORKQUEUE_HH
 
+#include <boost/noncopyable.hpp>
 #include <boost/function.hpp>
 #include <thread>
 #include <deque>

--- a/src/testSpinlock.cc
+++ b/src/testSpinlock.cc
@@ -14,6 +14,7 @@
 
 #include <stdint.h>
 #include <thread>
+#include <boost/noncopyable.hpp>
 #include <boost/random.hpp>
 
 using namespace boost;


### PR DESCRIPTION
Not all Boost versions put it in the same place.